### PR TITLE
Fix typo in function name

### DIFF
--- a/src/main/java/io/github/kingpulse/xdotool.java
+++ b/src/main/java/io/github/kingpulse/xdotool.java
@@ -91,7 +91,7 @@ public interface xdotool extends Library {
 
     int xdo_send_keysequence_window(final xdo_t xdo, X11.Window window, final String keysequence, int delay);
 
-    int xdo_second_keysequence_window_up(final xdo_t xdo, X11.Window window, final String keysequence, int delay);
+    int xdo_send_keysequence_window_up(final xdo_t xdo, X11.Window window, final String keysequence, int delay);
 
     int xdo_send_keysequence_window_down(final xdo_t xdo, X11.Window window, final String keysequence, int delay);
 


### PR DESCRIPTION
Fixes a typo in the `xdo_send_keysequence_window_up` function name